### PR TITLE
Extendable interfaces for require, module.require

### DIFF
--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -27,23 +27,30 @@ declare function clearInterval(intervalId: NodeJS.Timer): void;
 declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): any;
 declare function clearImmediate(immediateId: any): void;
 
-declare var require: {
+interface NodeRequireFunction {
     (id: string): any;
+}
+
+interface NodeRequire extends NodeRequireFunction {
     resolve(id:string): string;
     cache: any;
     extensions: any;
     main: any;
-};
+}
 
-declare var module: {
+declare var require: NodeRequire;
+
+interface NodeModule {
     exports: any;
-    require(id: string): any;
+    require: NodeRequireFunction;
     id: string;
     filename: string;
     loaded: boolean;
     parent: any;
     children: any[];
-};
+}
+
+declare var module: NodeModule;
 
 // Same as module.exports
 declare var exports: any;


### PR DESCRIPTION
Proposed fix for #4740 - "Node's `require` should implement a new interface `NodeRequire` (rather than direct signature) for specialized extension by other libraries"

usage example extending `require()` with a specialized overload for `'browser-window'`:

    interface NodeRequireFunction {
        (id: 'browser-window'): { new (options?: GitHubElectron.BrowserWindowOptions) : GitHubElectron.BrowserWindow }
    }

    // ...

    mainWindow = new BrowserWindow({ width: 800, height: 600 });


